### PR TITLE
Change API's docker image to 1.4.0

### DIFF
--- a/.github/workflows/publish-api-dockerhub.yml
+++ b/.github/workflows/publish-api-dockerhub.yml
@@ -6,11 +6,10 @@ on:
       - "main"
       - "deploy/dev"
       - "deploy/enterprise"
-      - "dify-for-mysql"
     tags:
       - "*"
   release:
-    types: [published]
+    types: [published, edited]
 
 concurrency:
   group: build-push-api-${{ github.head_ref || github.run_id }}

--- a/docker/docker-compose-mysql.yaml
+++ b/docker/docker-compose-mysql.yaml
@@ -500,7 +500,7 @@ x-shared-env: &shared-api-worker-env
 services:
   # API service
   api:
-    image: oceanbase/dify-api:cache-test
+    image: oceanbase/dify-api:1.4.0
     restart: always
     environment:
       # Use the shared environment variables.
@@ -529,7 +529,7 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
-    image: oceanbase/dify-api:cache-test
+    image: oceanbase/dify-api:1.4.0
     restart: always
     environment:
       # Use the shared environment variables.

--- a/docker/docker-compose-redis.yaml
+++ b/docker/docker-compose-redis.yaml
@@ -500,7 +500,7 @@ x-shared-env: &shared-api-worker-env
 services:
   # API service
   api:
-    image: oceanbase/dify-api:cache-test
+    image: oceanbase/dify-api:1.4.0
     restart: always
     environment:
       # Use the shared environment variables.
@@ -529,7 +529,7 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
-    image: oceanbase/dify-api:cache-test
+    image: oceanbase/dify-api:1.4.0
     restart: always
     environment:
       # Use the shared environment variables.


### PR DESCRIPTION
# Summary

fix:change api's image name tag from cache-test to 1.4.0

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

