### PR TITLE
feat: Set Redis as default cache and update dify-web to v1.8.0

### DIFF
--- a/docker/docker-compose-redis.yaml
+++ b/docker/docker-compose-redis.yaml
@@ -608,7 +608,7 @@ services:
 
   # Frontend web application.
   web:
-    image: langgenius/dify-web:1.7.0
+    image: langgenius/dify-web:1.8.0
     restart: always
     environment:
       CONSOLE_API_URL: ${CONSOLE_API_URL:-}

--- a/docker/setup-mysql-env.sh
+++ b/docker/setup-mysql-env.sh
@@ -218,7 +218,7 @@ update_env "VECTOR_STORE" "oceanbase"
 update_env "PIP_MIRROR_URL" "https://pypi.tuna.tsinghua.edu.cn/simple"
 
 # Redis configuration
-USE_REDIS=$(get_user_input "Use Redis for caching?  Y or N:" "N")
+USE_REDIS=$(get_user_input "Use Redis for caching?  Y or N:" "Y")
 
 if [ "$USE_REDIS" == "Y" ]; then
     print_message "info" "Configuring Redis cache..."


### PR DESCRIPTION
## Changes

This PR makes the following improvements:

### 🚀 Features
- **Set Redis as default cache option**: Changed the default cache option from MySQL to Redis in `setup-mysql-env.sh`
- **Update dify-web version**: Updated dify-web from v1.7.0 to v1.8.0 in `docker-compose-redis.yaml` to maintain version consistency

### 📝 Details
- Modified `docker/setup-mysql-env.sh` line 221: Changed default Redis option from "N" to "Y"
- Updated `docker/docker-compose-redis.yaml` line 611: Updated dify-web image from `langgenius/dify-web:1.7.0` to `langgenius/dify-web:1.8.0`

### ✅ Benefits
- Users can now easily use Redis caching by default without manual configuration
- Ensures version consistency across all docker-compose files
- Improves performance with Redis caching as the default option

### 🧪 Testing
- [x] Verified dify-web version consistency across docker-compose files
- [x] Confirmed Redis configuration works as expected